### PR TITLE
Feature - Improved Validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,13 +39,27 @@ func (t jsonTime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&formatted)
 }
 
+// serverAddress defines the structure of a server address.
+type serverAddress struct {
+	IP   net.IP `json:"ip"`
+	Port int    `json:"port"`
+}
+
+// String satisfies the fmt.Stringer interface and returns a string form of the
+// serverAddress structure.
+func (a *serverAddress) String() string {
+	return net.JoinHostPort(
+		a.IP.String(),
+		strconv.Itoa(a.Port),
+	)
+}
+
 // serverID defines the identifier of a particular server.
 type serverID string
 
 // server defines a structure for our server data.
 type server struct {
-	IP   net.IP `json:"ip"`
-	Port int    `json:"port"`
+	serverAddress // embedded to flatten the structure
 
 	Name        string `json:"name"`
 	GameVersion int    `json:"game_version"`
@@ -55,9 +69,7 @@ type server struct {
 
 // ID returns the serverID for a server, generated based on its internal data.
 func (s *server) ID() serverID {
-	strID := fmt.Sprintf("%s:%d", s.IP, s.Port)
-
-	return serverID(strID)
+	return serverID(s.serverAddress.String())
 }
 
 // serverRepository defines the structure for an in-memory server repository.

--- a/main.go
+++ b/main.go
@@ -225,69 +225,6 @@ func (r *serverRepository) Prune(threshold time.Duration) {
 // TODO: Move away from global references.
 var servers = newServerRepository()
 
-func verifyIP(ip string) bool {
-	// verify the IP address provided is valid.
-	// This just ensures it's _any_ IPv4 address.
-	addr := net.ParseIP(ip)
-	if addr.To4() == nil {
-		fmt.Fprintln(os.Stdout, ip, "is not a valid IPv4 address")
-		return false
-	}
-	return true
-}
-
-func verifyPort(port string) bool {
-	// Ensure the port is between 1024 and 65535 (applies in TCP and UDP)
-	if n, err := strconv.Atoi(port); err == nil {
-		if 1024 > n || n > 65535 {
-			// TODO: be a little more specific so they know what to do
-			fmt.Fprintln(os.Stdout, port, "is not a valid port number")
-			return false
-		}
-		return true
-	}
-	return false
-}
-
-func cleanName(servername string) string {
-	// Trim whitespace and newlines off ends of name
-	s := strings.TrimSpace(servername)
-	return s
-}
-
-func validateEntry(ctx *gin.Context, jname string, jip string, jport string) bool {
-	// Run simple input validation
-	// ctx == the gin context, for nabbing their source IP
-	// info = the serverInfo map of their JSON request data
-
-	// Your name should be in our required range.
-	// Your IP needs to be a real IPv4 address.
-	// Your jport needs to be in the ephemeral range.
-	// Your incoming source IP must match the IP in your payload.
-
-	// ip == their source client IP
-	// port == source port, only useful for logging/debugging
-	ip, _, _ := net.SplitHostPort(ctx.Request.RemoteAddr)
-
-	fmt.Fprintln(os.Stdout, "Source IP: "+ip+" Payload IP: "+jip)
-	if ip != jip {
-		return false // their source IP != JSON IP value, spoofing/typo case
-	}
-
-	// clean the name string and measure length here.
-	a := cleanName(jname)
-	if 3 > len(a) || len(a) > 32 {
-		fmt.Fprintln(os.Stdout, jname, "must be between 3 and 32 characters.")
-		return false
-	}
-	b := verifyIP(ip)      // their detected source IP
-	c := verifyPort(jport) // their port provided in the payload
-	if !b || !c {
-		return false
-	}
-	return true
-}
-
 // Called by servers to let clients know they exist
 // TODO: You really should be able to have multiple servers on one IP.
 func register(c *gin.Context) {


### PR DESCRIPTION
## Scope

This PR is an indirect follow-up to #14 and #11, and improves our input validation mechanisms by using structure-owned validation and providing for more helpful error messages to be returned to the calling API client.

Specifically, this PR completes/contains the following:

 - Separates the server address values into their own typed structure
     - This allows them to be used separately in contexts where it doesn't make sense to provide an entire (or partially-built) server data value (such as in the `remove` endpoint handler)
 - Adds new validation methods to the server value structures, to form a consistent interface for validation and to allow for easier validation delegation for nested structures
 - Uses the new validation mechanisms in the route handlers, and moves the client/request IP check to the handlers for an improved error flow (while removing the need to pass the request context to units that shouldn't know about a request context)
 - Removes the now unused older validation mechanism


## API Changes

This work is intended to be backwards compatible. **However**, the following client-facing API changes have been introduced:

 - New, more informative error result messages will be returned for the `POST /register` and `DELETE /remove`, depending on the validation errors that occurred
 - If a client attempts to register or remove a server whose IP doesn't match their client request IP, then a `403 Forbidden` HTTP status will be returned, along with a more informative error result message