### PR TITLE
Chore - Pragmatic Packaging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module Fugitive3dServerRepository
+module github.com/FugitiveTheGame/Fugitive3dServerRepository
 
 go 1.14
 

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -1,0 +1,3 @@
+// Package httpapi provides mechanisms, like handlers, to implement an HTTP API
+// for the application.
+package httpapi

--- a/internal/httpapi/reflection.go
+++ b/internal/httpapi/reflection.go
@@ -1,0 +1,23 @@
+package httpapi
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/gin-gonic/gin"
+)
+
+// HandleGetIP is a gin HTTP handler that gather's the source IP from an
+// incoming HTTP request and returns it in the response body.
+func HandleGetIP(ctx *gin.Context) {
+	ip, port, err := net.SplitHostPort(ctx.Request.RemoteAddr)
+	if err != nil {
+		fmt.Println(err.Error())
+		ctx.JSON(500, gin.H{"result": "internal server error"})
+		return
+	}
+
+	fmt.Println("Incoming request /getip:", ip+":"+port)
+	// Only return the IP, even though we have their source ephemeral port.
+	ctx.JSON(200, gin.H{"ip": ip})
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -1,0 +1,124 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/FugitiveTheGame/Fugitive3dServerRepository/srvrepo"
+	"github.com/gin-gonic/gin"
+)
+
+// ServerController is an HTTP API controller for server resources.
+type ServerController struct {
+	repository *srvrepo.ServerRepository
+}
+
+// NewServerController constructs a new Controller for controlling
+// server resources.
+func NewServerController(repository *srvrepo.ServerRepository) *ServerController {
+	return &ServerController{
+		repository: repository,
+	}
+}
+
+// HandleList is a gin HTTP handler that returns a list of the registered
+// servers in the response body.
+func (c *ServerController) HandleList(ctx *gin.Context) {
+	serverList := c.repository.List()
+
+	// Send server list to client
+	ctx.JSON(http.StatusOK, serverList)
+}
+
+// HandleRegister is a gin HTTP handler that allows servers to register
+// themselves in the repository.
+func (c *ServerController) HandleRegister(ctx *gin.Context) {
+	requestAddr, _ := srvrepo.ParseServerAddress(ctx.Request.RemoteAddr)
+	var serverData srvrepo.Server
+
+	// New servers are tracked for 60 seconds unless updated.
+	body, _ := ioutil.ReadAll(ctx.Request.Body)
+	if err := json.Unmarshal(body, &serverData); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"result": "invalid request JSON"})
+	}
+
+	// Update the last-seen value to "now"
+	serverData.Seen()
+
+	// Debug printing
+	//fmt.Println(string(body), serverData)
+
+	fmt.Println("A server is registering.")
+
+	if err := serverData.Validate(); err != nil {
+		fmt.Printf("error during input validation: %v\n", err)
+		ctx.JSON(http.StatusBadRequest, gin.H{"result": err.Error()})
+		return
+	}
+
+	if !serverData.IP.Equal(requestAddr.IP) {
+		err := fmt.Errorf("request IP address does not match client IP address")
+
+		fmt.Printf("error during request validation: %v\n", err)
+		ctx.JSON(http.StatusForbidden, gin.H{"result": err.Error()})
+		return
+	}
+
+	existed, err := c.repository.Register(serverData)
+	if err != nil {
+		fmt.Printf("error registering server: %v\n", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"result": "internal server error"})
+		return
+	}
+
+	if existed {
+		fmt.Println("This server is already registered.")
+		ctx.JSON(http.StatusOK, gin.H{"result": "updated"})
+		return
+	}
+
+	fmt.Println("New server registered!")
+	ctx.JSON(http.StatusCreated, gin.H{"result": "registered"})
+}
+
+// HandleRemove is a gin HTTP handler that allows servers to remove themselves
+// from the repository.
+func (c *ServerController) HandleRemove(ctx *gin.Context) {
+	requestAddr, _ := srvrepo.ParseServerAddress(ctx.Request.RemoteAddr)
+	var serverAddr srvrepo.ServerAddress
+
+	// New servers are tracked for 60 seconds unless updated.
+	body, _ := ioutil.ReadAll(ctx.Request.Body)
+	if err := json.Unmarshal(body, &serverAddr); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"result": "invalid request JSON"})
+	}
+
+	fmt.Println("A server is being removed.")
+
+	if err := serverAddr.Validate(); err != nil {
+		fmt.Printf("error during input validation: %v\n", err)
+		ctx.JSON(http.StatusBadRequest, gin.H{"result": err.Error()})
+		return
+	}
+
+	if !serverAddr.IP.Equal(requestAddr.IP) {
+		err := fmt.Errorf("request IP address does not match client IP address")
+
+		fmt.Printf("error during request validation: %v\n", err)
+		ctx.JSON(http.StatusForbidden, gin.H{"result": err.Error()})
+		return
+	}
+
+	exists := c.repository.Remove(srvrepo.ServerID(serverAddr.String()))
+
+	if !exists {
+		fmt.Println("The server was not found.")
+		ctx.JSON(http.StatusNotFound, gin.H{"result": "failure"})
+		return
+	}
+
+	fmt.Println("This server is being removed.")
+	ctx.JSON(200, gin.H{"result": "success"})
+}

--- a/main.go
+++ b/main.go
@@ -1,16 +1,16 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
+	"github.com/FugitiveTheGame/Fugitive3dServerRepository/internal/httpapi"
 	"github.com/FugitiveTheGame/Fugitive3dServerRepository/srvrepo"
 	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
@@ -19,132 +19,15 @@ import (
 // test it out
 // curl -d '{"name":"special server", "ip":"1.2.3.5", "port":"45677"}' -H "Content-Type: application/json" -X POST localhost:8080/register
 
-// Our in-memory storage for registered servers
-// TODO: Move away from global references.
-var servers = srvrepo.NewServerRepository()
-
-// Called by servers to let clients know they exist
-// TODO: You really should be able to have multiple servers on one IP.
-func register(c *gin.Context) {
-	requestAddr, _ := srvrepo.ParseServerAddress(c.Request.RemoteAddr)
-	var serverData srvrepo.Server
-
-	// New servers are tracked for 60 seconds unless updated.
-	body, _ := ioutil.ReadAll(c.Request.Body)
-	if err := json.Unmarshal(body, &serverData); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"result": "invalid request JSON"})
-	}
-
-	// Update the last-seen value to "now"
-	serverData.Seen()
-
-	// Debug printing
-	//fmt.Println(string(body), serverData)
-
-	fmt.Println("A server is registering.")
-
-	if err := serverData.Validate(); err != nil {
-		fmt.Printf("error during input validation: %v\n", err)
-		c.JSON(http.StatusBadRequest, gin.H{"result": err.Error()})
-		return
-	}
-
-	if !serverData.IP.Equal(requestAddr.IP) {
-		err := fmt.Errorf("request IP address does not match client IP address")
-
-		fmt.Printf("error during request validation: %v\n", err)
-		c.JSON(http.StatusForbidden, gin.H{"result": err.Error()})
-		return
-	}
-
-	existed, err := servers.Register(serverData)
-	if err != nil {
-		fmt.Printf("error registering server: %v\n", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"result": "internal server error"})
-		return
-	}
-
-	if existed {
-		fmt.Println("This server is already registered.")
-		c.JSON(http.StatusOK, gin.H{"result": "updated"})
-		return
-	}
-
-	fmt.Println("New server registered!")
-	c.JSON(http.StatusCreated, gin.H{"result": "registered"})
-}
-
-// Called by clients to get a list of active servers
-func list(c *gin.Context) {
-	serverList := servers.List()
-
-	// Send server list to client
-	c.JSON(http.StatusOK, serverList)
-}
-
-// Gather the source IP from an incoming HTTP request.
-func getip(c *gin.Context) {
-	ip, port, err := net.SplitHostPort(c.Request.RemoteAddr)
-	if err != nil {
-		fmt.Println(err.Error())
-		c.JSON(500, gin.H{"result": "internal server error"})
-	} else {
-		fmt.Println("Incoming request /getip:", ip+":"+port)
-		// Only return the IP, even though we have their source ephemeral port.
-		c.JSON(200, gin.H{"ip": ip})
-	}
-}
-
-// Allow servers to remove _themselves_ from the list when requested.
-// They cannot remove entries for IP addresses other than their origin IP.
-// Only jerks do that.
-func remove(c *gin.Context) {
-	requestAddr, _ := srvrepo.ParseServerAddress(c.Request.RemoteAddr)
-	var serverAddr srvrepo.ServerAddress
-
-	// New servers are tracked for 60 seconds unless updated.
-	body, _ := ioutil.ReadAll(c.Request.Body)
-	if err := json.Unmarshal(body, &serverAddr); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"result": "invalid request JSON"})
-	}
-
-	fmt.Println("A server is being removed.")
-
-	if err := serverAddr.Validate(); err != nil {
-		fmt.Printf("error during input validation: %v\n", err)
-		c.JSON(http.StatusBadRequest, gin.H{"result": err.Error()})
-		return
-	}
-
-	if !serverAddr.IP.Equal(requestAddr.IP) {
-		err := fmt.Errorf("request IP address does not match client IP address")
-
-		fmt.Printf("error during request validation: %v\n", err)
-		c.JSON(http.StatusForbidden, gin.H{"result": err.Error()})
-		return
-	}
-
-	exists := servers.Remove(srvrepo.ServerID(serverAddr.String()))
-
-	if !exists {
-		fmt.Println("The server was not found.")
-		c.JSON(http.StatusNotFound, gin.H{"result": "failure"})
-		return
-	}
-
-	fmt.Println("This server is being removed.")
-	c.JSON(200, gin.H{"result": "success"})
-}
-
 // pruneServers takes a threshold duration for server age to prune old servers,
 // running via an infinite ticker that ticks at half the duration of the given
 // threshold.
-func pruneServers(threshold time.Duration) {
+func pruneServers(repository *srvrepo.ServerRepository, threshold time.Duration) {
 	// The interval is half the treshold
 	interval := threshold / 2
 
 	for range time.Tick(interval) {
-		servers.Prune(threshold)
+		repository.Prune(threshold)
 	}
 }
 
@@ -159,26 +42,37 @@ func main() {
 	flag.IntVar(&staleThreshold, "s", 30, "Duration (in seconds) before a server is marked stale")
 	flag.Parse()
 
-	s := fmt.Sprintf("Server starting with arguments: %s:%d staleThreshold=%v", ipAddr, portNum, staleThreshold)
+	serveAddr := net.JoinHostPort(ipAddr, strconv.Itoa(portNum))
+
+	s := fmt.Sprintf("Server starting with arguments: %s staleThreshold=%v", serveAddr, staleThreshold)
 	fmt.Println(s)
+
+	router := initApp(staleThreshold)
+
+	http.ListenAndServe(serveAddr, router)
+}
+
+func initApp(staleThreshold int) http.Handler {
+	// Log to a file (overwrite) and stdout
+	f, _ := os.Create("gin-server.log")
+
+	// TODO: This is overriding globally. We should likely use a better scope.
+	gin.DefaultWriter = io.MultiWriter(f, os.Stdout)
 
 	router := gin.Default()
 	router.Use(gzip.Gzip(gzip.DefaultCompression))
 
-	// Log to a file (overwrite) and stdout
-	f, _ := os.Create("gin-server.log")
-	gin.DefaultWriter = io.MultiWriter(f, os.Stdout)
+	repository := srvrepo.NewServerRepository()
+	srvController := httpapi.NewServerController(repository)
 
-	// Register endpoints
-	router.POST("/register", register)
-	router.GET("/list", list)
-	router.GET("/getip", getip)
-	router.DELETE("/remove", remove)
+	// Register endpoint handlers
+	router.GET("/getip", httpapi.HandleGetIP)
+	router.GET("/list", srvController.HandleList)
+	router.POST("/register", srvController.HandleRegister)
+	router.DELETE("/remove", srvController.HandleRemove)
 
 	// thread w/locking for the pruning operations
-	go pruneServers(time.Duration(staleThreshold) * time.Second)
+	go pruneServers(repository, time.Duration(staleThreshold)*time.Second)
 
-	// Start her up!
-	p := fmt.Sprintf("%s:%d", ipAddr, portNum)
-	router.Run(p)
+	return router
 }

--- a/main.go
+++ b/main.go
@@ -9,11 +9,9 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strconv"
-	"strings"
-	"sync"
 	"time"
 
+	"github.com/FugitiveTheGame/Fugitive3dServerRepository/srvrepo"
 	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
 )
@@ -21,215 +19,15 @@ import (
 // test it out
 // curl -d '{"name":"special server", "ip":"1.2.3.5", "port":"45677"}' -H "Content-Type: application/json" -X POST localhost:8080/register
 
-// timeFormatJSON defines the format that we use for time formatting in JSON.
-const timeFormatJSON = time.RFC3339
-
-// port range min and max values for valid server address ports.
-const (
-	portRangeMin = 1024
-	portRangeMax = 65535
-)
-
-// name length min and max values for valid server names.
-const (
-	nameLengthMin = 3
-	nameLengthMax = 32
-)
-
-// jsonTime defines a time.Time with custom marshalling (embedded for method
-// access, rather than aliasing)
-type jsonTime struct {
-	time.Time
-	// put nothing else here...
-}
-
-// MarshalJSON satisfies the encoding/json.Marshaler interface and customizes
-// the JSON formatting of the jsonTime structure.
-func (t jsonTime) MarshalJSON() ([]byte, error) {
-	formatted := t.Format(timeFormatJSON)
-
-	return json.Marshal(&formatted)
-}
-
-// serverAddress defines the structure of a server address.
-type serverAddress struct {
-	IP   net.IP `json:"ip"`
-	Port int    `json:"port"`
-}
-
-// parseServerAddress parses a string address into a serverAddress, returning
-// the parsed value and any errors that occurred during parsing.
-func parseServerAddress(s string) (serverAddress, error) {
-	var addr serverAddress
-
-	rawIP, rawPort, err := net.SplitHostPort(s)
-	if err != nil {
-		return addr, err
-	}
-
-	ip := net.ParseIP(rawIP)
-	port, err := strconv.Atoi(rawPort)
-	if err != nil {
-		return addr, fmt.Errorf("invalid port number with err: %w", err)
-	}
-
-	addr = serverAddress{
-		IP:   ip,
-		Port: port,
-	}
-
-	return addr, nil
-}
-
-// String satisfies the fmt.Stringer interface and returns a string form of the
-// serverAddress structure.
-func (a *serverAddress) String() string {
-	return net.JoinHostPort(
-		a.IP.String(),
-		strconv.Itoa(a.Port),
-	)
-}
-
-// Validate runs validations on the value and returns an error if the value is
-// invalid for any reason.
-func (a *serverAddress) Validate() error {
-	if a.IP.To4() == nil {
-		return fmt.Errorf("IP is not a valid IPv4 address")
-	}
-
-	if a.Port < portRangeMin || a.Port > portRangeMax {
-		return fmt.Errorf("port is not within the valid port range of %d-%d", portRangeMin, portRangeMax)
-	}
-
-	return nil
-}
-
-// serverID defines the identifier of a particular server.
-type serverID string
-
-// server defines a structure for our server data.
-type server struct {
-	serverAddress // embedded to flatten the structure
-
-	Name        string `json:"name"`
-	GameVersion int    `json:"game_version"`
-
-	LastSeen jsonTime `json:"last_seen"`
-}
-
-// ID returns the serverID for a server, generated based on its internal data.
-func (s *server) ID() serverID {
-	return serverID(s.serverAddress.String())
-}
-
-// Validate runs validations on the value and returns an error if the value is
-// invalid for any reason.
-func (s *server) Validate() error {
-	if err := s.serverAddress.Validate(); err != nil {
-		return err
-	}
-
-	// TODO: We likely should be cleaning/normalizing inputs when unmarshalling,
-	// rather than during validation.
-	s.Name = strings.TrimSpace(s.Name)
-	if nameLength := len(s.Name); nameLength < nameLengthMin || nameLength > nameLengthMax {
-		return fmt.Errorf("name length must be within range of %d-%d", nameLengthMin, nameLengthMax)
-	}
-
-	return nil
-}
-
-// serverRepository defines the structure for an in-memory server repository.
-type serverRepository struct {
-	servers map[serverID]server
-
-	mu sync.RWMutex
-}
-
-// newServerRepository returns a pointer to a new initialized serverRepository.
-func newServerRepository() *serverRepository {
-	return &serverRepository{
-		servers: make(map[serverID]server),
-	}
-}
-
-// List returns a slice representation of the servers in the repository.
-func (r *serverRepository) List() []server {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	serverList := make([]server, 0, len(r.servers))
-
-	for _, srv := range r.servers {
-		serverList = append(serverList, srv)
-	}
-
-	return serverList
-}
-
-// Register takes a server and registers it with the repository, returning a
-// bool that represents whether the server already existed or not (true for
-// already exists, false otherwise), and a potential error if the registration
-// failed.
-func (r *serverRepository) Register(srv server) (bool, error) {
-	alreadyExists := false
-	var err error
-
-	// TODO: Normalize? Validate?
-	id := srv.ID()
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	_, alreadyExists = r.servers[id]
-	r.servers[id] = srv
-
-	return alreadyExists, err
-}
-
-// Remove takes a serverID and removes the corresponding server from the
-// repository, returning a bool that represents whether the server existed or
-// not (true for exists, false otherwise).
-func (r *serverRepository) Remove(id serverID) bool {
-	exists := false
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	_, exists = r.servers[id]
-	delete(r.servers, id)
-
-	return exists
-}
-
-// Prune takes a time.Duration representing the threshold of when a server's
-// last-seen "age" should be considered too old, and removes those servers from
-// the repository.
-func (r *serverRepository) Prune(threshold time.Duration) {
-	cutoff := time.Now().Add(-threshold)
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	for id, srv := range r.servers {
-		if srv.LastSeen.Before(cutoff) {
-			// TODO: Log with an abstraction
-			fmt.Printf("Pruning server: %s\n", id)
-
-			delete(r.servers, id)
-		}
-	}
-}
-
 // Our in-memory storage for registered servers
 // TODO: Move away from global references.
-var servers = newServerRepository()
+var servers = srvrepo.NewServerRepository()
 
 // Called by servers to let clients know they exist
 // TODO: You really should be able to have multiple servers on one IP.
 func register(c *gin.Context) {
-	requestAddr, _ := parseServerAddress(c.Request.RemoteAddr)
-	var serverData server
+	requestAddr, _ := srvrepo.ParseServerAddress(c.Request.RemoteAddr)
+	var serverData srvrepo.Server
 
 	// New servers are tracked for 60 seconds unless updated.
 	body, _ := ioutil.ReadAll(c.Request.Body)
@@ -238,7 +36,7 @@ func register(c *gin.Context) {
 	}
 
 	// Update the last-seen value to "now"
-	serverData.LastSeen = jsonTime{time.Now()}
+	serverData.Seen()
 
 	// Debug printing
 	//fmt.Println(string(body), serverData)
@@ -301,8 +99,8 @@ func getip(c *gin.Context) {
 // They cannot remove entries for IP addresses other than their origin IP.
 // Only jerks do that.
 func remove(c *gin.Context) {
-	requestAddr, _ := parseServerAddress(c.Request.RemoteAddr)
-	var serverAddr serverAddress
+	requestAddr, _ := srvrepo.ParseServerAddress(c.Request.RemoteAddr)
+	var serverAddr srvrepo.ServerAddress
 
 	// New servers are tracked for 60 seconds unless updated.
 	body, _ := ioutil.ReadAll(c.Request.Body)
@@ -326,7 +124,7 @@ func remove(c *gin.Context) {
 		return
 	}
 
-	exists := servers.Remove(serverID(serverAddr.String()))
+	exists := servers.Remove(srvrepo.ServerID(serverAddr.String()))
 
 	if !exists {
 		fmt.Println("The server was not found.")

--- a/srvrepo/constraint.go
+++ b/srvrepo/constraint.go
@@ -1,0 +1,12 @@
+package srvrepo
+
+// internal validation constraint definitions
+const (
+	// port range min and max values for valid server address ports.
+	portRangeMin = 1024
+	portRangeMax = 65535
+
+	// name length min and max values for valid server names.
+	nameLengthMin = 3
+	nameLengthMax = 32
+)

--- a/srvrepo/json.go
+++ b/srvrepo/json.go
@@ -1,0 +1,24 @@
+package srvrepo
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// timeFormatJSON defines the format that we use for time formatting in JSON.
+const timeFormatJSON = time.RFC3339
+
+// jsonTime defines a time.Time with custom marshalling (embedded for method
+// access, rather than aliasing)
+type jsonTime struct {
+	time.Time
+	// put nothing else here...
+}
+
+// MarshalJSON satisfies the encoding/json.Marshaler interface and customizes
+// the JSON formatting of the jsonTime structure.
+func (t jsonTime) MarshalJSON() ([]byte, error) {
+	formatted := t.Format(timeFormatJSON)
+
+	return json.Marshal(&formatted)
+}

--- a/srvrepo/srvrepo.go
+++ b/srvrepo/srvrepo.go
@@ -1,0 +1,187 @@
+// Package srvrepo defines the public (externally importable) interfaces, types,
+// and functions for interacting with the server repository.
+package srvrepo
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Server defines a structure for our server data.
+type Server struct {
+	ServerAddress // embedded to flatten the structure
+
+	Name        string `json:"name"`
+	GameVersion int    `json:"game_version"`
+
+	LastSeen jsonTime `json:"last_seen"`
+}
+
+// ID returns the ServerID for a server, generated based on its internal data.
+func (s *Server) ID() ServerID {
+	return ServerID(s.ServerAddress.String())
+}
+
+// Seen marks the server as "seen", updating the `LastSeen` property value.
+func (s *Server) Seen() {
+	s.LastSeen = jsonTime{time.Now()}
+}
+
+// Validate runs validations on the value and returns an error if the value is
+// invalid for any reason.
+func (s *Server) Validate() error {
+	if err := s.ServerAddress.Validate(); err != nil {
+		return err
+	}
+
+	// TODO: We likely should be cleaning/normalizing inputs when unmarshalling,
+	// rather than during validation.
+	s.Name = strings.TrimSpace(s.Name)
+	if nameLength := len(s.Name); nameLength < nameLengthMin || nameLength > nameLengthMax {
+		return fmt.Errorf("name length must be within range of %d-%d", nameLengthMin, nameLengthMax)
+	}
+
+	return nil
+}
+
+// ServerAddress defines the structure of a server address.
+type ServerAddress struct {
+	IP   net.IP `json:"ip"`
+	Port int    `json:"port"`
+}
+
+// ParseServerAddress parses a string address into a ServerAddress, returning
+// the parsed value and any errors that occurred during parsing.
+func ParseServerAddress(s string) (ServerAddress, error) {
+	var addr ServerAddress
+
+	rawIP, rawPort, err := net.SplitHostPort(s)
+	if err != nil {
+		return addr, err
+	}
+
+	ip := net.ParseIP(rawIP)
+	port, err := strconv.Atoi(rawPort)
+	if err != nil {
+		return addr, fmt.Errorf("invalid port number with err: %w", err)
+	}
+
+	addr = ServerAddress{
+		IP:   ip,
+		Port: port,
+	}
+
+	return addr, nil
+}
+
+// String satisfies the fmt.Stringer interface and returns a string form of the
+// ServerAddress structure.
+func (a *ServerAddress) String() string {
+	return net.JoinHostPort(
+		a.IP.String(),
+		strconv.Itoa(a.Port),
+	)
+}
+
+// Validate runs validations on the value and returns an error if the value is
+// invalid for any reason.
+func (a *ServerAddress) Validate() error {
+	if a.IP.To4() == nil {
+		return fmt.Errorf("IP is not a valid IPv4 address")
+	}
+
+	if a.Port < portRangeMin || a.Port > portRangeMax {
+		return fmt.Errorf("port is not within the valid port range of %d-%d", portRangeMin, portRangeMax)
+	}
+
+	return nil
+}
+
+// ServerID defines the identifier of a particular server.
+type ServerID string
+
+// ServerRepository defines the structure for an in-memory server repository.
+type ServerRepository struct {
+	servers map[ServerID]Server
+
+	mu sync.RWMutex
+}
+
+// NewServerRepository returns a pointer to a new initialized ServerRepository.
+func NewServerRepository() *ServerRepository {
+	return &ServerRepository{
+		servers: make(map[ServerID]Server),
+	}
+}
+
+// List returns a slice representation of the servers in the repository.
+func (r *ServerRepository) List() []Server {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	serverList := make([]Server, 0, len(r.servers))
+
+	for _, srv := range r.servers {
+		serverList = append(serverList, srv)
+	}
+
+	return serverList
+}
+
+// Register takes a Server and registers it with the repository, returning a
+// bool that represents whether the server already existed or not (true for
+// already exists, false otherwise), and a potential error if the registration
+// failed.
+func (r *ServerRepository) Register(srv Server) (bool, error) {
+	alreadyExists := false
+	var err error
+
+	// TODO: Normalize? Validate?
+	id := srv.ID()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	_, alreadyExists = r.servers[id]
+	r.servers[id] = srv
+
+	return alreadyExists, err
+}
+
+// Remove takes a ServerID and removes the corresponding server from the
+// repository, returning a bool that represents whether the server existed or
+// not (true for exists, false otherwise).
+func (r *ServerRepository) Remove(id ServerID) bool {
+	exists := false
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	_, exists = r.servers[id]
+	delete(r.servers, id)
+
+	return exists
+}
+
+// Prune takes a time.Duration representing the threshold of when a server's
+// last-seen "age" should be considered too old, and removes those servers from
+// the repository.
+func (r *ServerRepository) Prune(threshold time.Duration) {
+	cutoff := time.Now().Add(-threshold)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for id, srv := range r.servers {
+		if srv.LastSeen.Before(cutoff) {
+			// TODO: Log with an abstraction
+			fmt.Printf("Pruning server: %s\n", id)
+
+			delete(r.servers, id)
+		}
+	}
+}


### PR DESCRIPTION
# Scope

This PR is a re-implementation of #16, after the review comments made by @Wavesonics and further discussion made it clear that we should provide package separation without unnecessary abstraction, to keep the code-base simple. This PR attempts to realize those goals with a much simpler package structure while still keeping a boundary between package responsibilities.

With that in mind, this PR is a follow-up to #14 and #11, with the intent to improve the code's quality through separating the various bits that were static, global, and all in the `main.go` file into separate packages with their own responsibilities.

Specifically, this PR completes/contains the following:

 - Renames the module to use a fully-qualified name
     - See: https://blog.golang.org/using-go-modules
 - Splits up the internal server types and methods into their own package, to start packaging the components of the app
 - Moves the HTTP handlers to their own package, and restructuring the handlers that share dependencies
     - This furthers the repackaging effort, while allowing us to remove reliance on globals


# Structure

_Reviewers may find this section useful as a "guide" in the process of reviewing this PR._

While the previous code was all contained in `main.go`, these changes introduce some packages and types to separate them and provide boundaries. **Unlike the previous PR that this replaces, the structure here is much simpler.** An overview is as follows:

 - `package main` - This is where the application starts, per usual. Not much has changed here.
 - `package srvrepo` - This contains the **public** (importable by external modules/sources) code that houses both the high level interface of the "service" and its implementation.
 - `package internal` - This is but a container to separate the internal application code that shouldn't be importable by other Go modules.
     - `package httpapi` - This contains the gin HTTP handlers that implement the public API interaction code.


## NOTE

The package naming and containment follow the conventions/idioms of popular packages and/or the official documentation. For more info, see:

 - https://golang.org/doc/effective_go.html
     - Mostly the section on [**names**](https://golang.org/doc/effective_go.html#names)
 - https://rakyll.org/style-packages/
 - https://golang.org/doc/go1.4#internalpackages
 - https://dave.cheney.net/2019/10/06/use-internal-packages-to-reduce-your-public-api-surface


# API Changes

This work is intended to be completely backwards compatible. No external APIs should be effected.