### PR TITLE
Feature - REST Refactor

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,10 +66,10 @@ func initApp(staleThreshold int) http.Handler {
 	srvController := httpapi.NewServerController(repository)
 
 	// Register endpoint handlers
-	router.GET("/getip", httpapi.HandleGetIP)
-	router.GET("/list", srvController.HandleList)
-	router.POST("/register", srvController.HandleRegister)
-	router.DELETE("/remove", srvController.HandleRemove)
+	router.GET("/reflection/ip", httpapi.HandleGetIP)
+	router.GET("/servers", srvController.HandleList)
+	router.PUT("/servers/:server_id", srvController.HandleRegister)
+	router.DELETE("/servers/:server_id", srvController.HandleRemove)
 
 	// thread w/locking for the pruning operations
 	go pruneServers(repository, time.Duration(staleThreshold)*time.Second)


### PR DESCRIPTION
# Scope

This PR refactors the endpoints and handlers into a more RESTful HTTP representation, using the server addresses as public resource identifiers.


# API Changes

⚠️ **This PR changes the location of every endpoint!** ⚠️

The following are the new endpoint locations:

| Endpoint           | Old Location     | New Location                 |
|--------------------|------------------|------------------------------|
| Return client's IP | `GET /getip`     | `GET /reflection/ip`         |
| List servers       | `GET /list`      | `GET /servers`               |
| Register a server  | `POST /register` | `PUT /servers/:server_id`    |
| Remove a server    | `DELETE /remove` | `DELETE /servers/:server_id` |

`server_id` is a string in the form of `ip:port` (example: `127.0.0.1:1337`)