### PR TITLE
Ping pong

### DIFF
--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -49,7 +49,7 @@ func (c *ServerController) HandleUpdate(ctx *gin.Context) {
 	serverAddr, err := srvrepo.ParseServerAddress(ctx.Param("server_id"))
 	if err != nil {
 		// 404, since the ID is a URL param
-		ctx.JSON(http.StatusNotFound, gin.H{"result": "invalid server ID"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"result": "invalid server ID"})
 		return
 	}
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -54,6 +54,13 @@ func (c *ServerController) HandleUpdate(ctx *gin.Context) {
 		return
 	}
 
+	// If we have never seen this server, require that they POST first
+	existed, err := c.repository.Has(srvrepo.ServerID(serverAddr.String()))
+	if !existed {
+		ctx.JSON(http.StatusPreconditionRequired, gin.H{"result": "must POST first"})
+		return
+	}
+
 	// Make sure that the provided address is what's set in the data, so that
 	// the server data and ID match.
 	serverData.ServerAddress = serverAddr
@@ -77,7 +84,7 @@ func (c *ServerController) HandleUpdate(ctx *gin.Context) {
 
 	fmt.Println("A server is registering.")
 
-	existed, err := c.repository.Register(serverData)
+	existed, err = c.repository.Register(serverData)
 	if err != nil {
 		fmt.Printf("error registering server: %v\n", err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"result": "internal server error"})

--- a/main.go
+++ b/main.go
@@ -68,7 +68,8 @@ func initApp(staleThreshold int) http.Handler {
 	// Register endpoint handlers
 	router.GET("/reflection/ip", httpapi.HandleGetIP)
 	router.GET("/servers", srvController.HandleList)
-	router.PUT("/servers/:server_id", srvController.HandleRegister)
+	router.POST("/servers/:server_id", srvController.HandleRegister)
+	router.PUT("/servers/:server_id", srvController.HandleUpdate)
 	router.DELETE("/servers/:server_id", srvController.HandleRemove)
 
 	// thread w/locking for the pruning operations

--- a/srvrepo/srvrepo.go
+++ b/srvrepo/srvrepo.go
@@ -119,16 +119,15 @@ func NewServerRepository() *ServerRepository {
 }
 
 // Check if an given ServerID already exists in the repository
-func (r *ServerRepository) Has(id ServerID) (bool, error) {
+func (r *ServerRepository) Has(id ServerID) bool {
 	alreadyExists := false
-	var err error
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	_, alreadyExists = r.servers[id]
 
-	return alreadyExists, err
+	return alreadyExists
 }
 
 // List returns a slice representation of the servers in the repository.

--- a/srvrepo/srvrepo.go
+++ b/srvrepo/srvrepo.go
@@ -118,6 +118,19 @@ func NewServerRepository() *ServerRepository {
 	}
 }
 
+// Check if an given ServerID already exists in the repository
+func (r *ServerRepository) Has(id ServerID) (bool, error) {
+	alreadyExists := false
+	var err error
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	_, alreadyExists = r.servers[id]
+
+	return alreadyExists, err
+}
+
 // List returns a slice representation of the servers in the repository.
 func (r *ServerRepository) List() []Server {
 	r.mu.RLock()


### PR DESCRIPTION
This now differentiates from initial registration and simple updates.

Game servers will first **POST** to the `server/` endpoint. When they do so, they will open the port being registered and wait for a UDP packet from the repository.

The repository will send 10 "ping" packets and wait for a response. The game server will respond with "pong". Only when the repository receives this "pong" packet will it actually register the game server.

The game server will move on to begin actually hosting the game, and all subsequent heart beat updates will **PUT** the `server/` endpoint.

This relies on the Fugitive3D Branch: `port-check`